### PR TITLE
Remove .dev example for local development in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,8 @@ ensure that your subdomain is listed in your hosts file.
 
 On Linux or OSX, add your subdomain to `/etc/hosts`:
 ```
-127.0.0.1       myapp.dev
-127.0.0.1       subdomain.myapp.dev
+127.0.0.1       myapp.tech
+127.0.0.1       subdomain.myapp.tech
 ```
 
 You may not have write permissions on your hosts file, in which case you can


### PR DESCRIPTION
 As of Chrome 63, Chrome will force `.dev` domains to HTTPS via preloaded HSTS. So it's better to not go through the hassle of setting up https for localhost and just simply use another top level domain like `.tech` for local development.