### PR TITLE
Require wildcard routes to be present

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = function(subdomain, fn) {
       var expected = subdomainSplit[len - (i+1)];
       var actual = req.subdomains[i+req._subdomainLevel];
 
-      if(expected === '*') { continue; }
+      if(expected === '*' && actual) { continue; }
 
       if(actual !== expected) {
           match = false;


### PR DESCRIPTION
Currently, '*' matches both https://user.example.com and https://example.com. However, this doesn't make a ton of sense, and it makes it really hard to represent a bunch of common use-cases. 

This is probably a breaking change, and it should probably get a version bump. I'm also open to suggestions to make it a non-breaking change (like adding an option flag to control this behavior) or a less-breaking change (like using a different symbol (`+`) for wildcards that require the presence of a domain and wildcards that don't). It's your repository, tell me what you think is best!

tests should also be added around this behavior. I didn't look super closely but i don't think this breaks any existing tests.