### PR TITLE
Set req.subdomains to an array of subdomains.

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,19 +18,24 @@ module.exports = function(subdomain, fn) {
     //url - v2.api.example.dom
     //subdomains == ['api', 'v2']
     //subdomainSplit = ['v2', 'api']
+    const subdomains = [];
     for(var i = 0; i < len; i++) {
       var expected = subdomainSplit[len - (i+1)];
       var actual = req.subdomains[i+req._subdomainLevel];
+
 
       if(expected === '*') { continue; }
 
       if(actual !== expected) {
           match = false;
           break;
+      } else {
+        subdomains.push(actual);
       }
     }
 
     if(match) {
+      req.subdomains = subdomains;
       req._subdomainLevel++;//enables chaining
       return fn(req, res, next);
     }


### PR DESCRIPTION
Allows you to get the wildcard domains via req.subdomains[0], req.subdomains[1], [...], in the order presented right to left. ex. *.*.example.com -> bro.test.example.com would return ["test", "bro"] in the req.subdomains field.